### PR TITLE
Proposal for the initial set of AMP Working Groups

### DIFF
--- a/working-groups/README.md
+++ b/working-groups/README.md
@@ -33,7 +33,7 @@ AMP’s Working Groups are:
   * Responsible for implementing and improving AMP's story format (amp-story).
   * Facilitator: @newmuis
 * **UI.**
-  * Responsible for AMP's visual components & interactions.
+  * Responsible for AMP's visual components & interactions.  The UI WG also has overall responsibility for ensuring AMP is accessible, though each WG is responsible for ensuring accessibility within their areas of responsibility. 
   * Facilitator: @aghassemi
 * **UX.**
   * Responsible for AMP’s user experience, including published guidelines for AMP UX.

--- a/working-groups/README.md
+++ b/working-groups/README.md
@@ -1,7 +1,38 @@
 # Working Groups
 
-Each AMP Working Group is a segment of the community with knowledge/interest in specific area of AMP, with a mandate provided by the Technical Steering Committee.  See [GOVERNANCE.md](../GOVERNANCE.md#working-groups) for more details.
 
-## List of working groups
+An AMP [Working Groups](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md#working-groups) is a segment of the community with knowledge/interest in specific area of AMP.  Working Groups are created by AMP’s [Technical Steering Committee](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md#technical-steering-committee-tsc). 
 
-*This section is pending the creation of Working Groups by the TSC.*
+AMP’s Working Groups are:
+
+* **Ads & analytics.**
+  * Responsible for ads & analytics features and integrations in AMP.
+  * Facilitator: @lannka
+* **AMP4Email.**
+  * Responsible for the AMP4Email project.
+  * Facilitator: @choumx
+* **Approvers.**
+  * Responsible for approving changes that have a significant impact on AMP's behavior or significant new features as described in the feature and bug fix process.
+  * Facilitator: @dvoytenko
+* **Infrastructure.**
+  * Responsible for AMP's infrastructure, including building, testing and release.
+  * Facilitator: @rsimha
+* **Outreach.**
+  * Responsible for helping developers who use AMP remain productive and keeping the AMP community healthy.  This includes maintaining and enhancing AMP's developer-facing sites and documentation, maintaining communication channels, organizing community events, etc.
+  * Facilitator: @pbakaus
+* **Runtime.**
+  * Responsible for AMP's core runtime, such as layout/rendering and data binding.
+  * Facilitator: @jridgewell
+* **Stories.**
+  * Responsible for implementing and improving AMP's story format (amp-story).
+  * Facilitator: @newmuis
+* **UI.**
+  * Responsible for AMP's visual components & interactions.
+  * Facilitator: @aghassemi
+* **UX.**
+  * Responsible for AMP’s user experience, including published guidelines for AMP UX.
+  * Facilitator: @spacedino
+* **Validation & caching.**
+  * Responsible for AMP's validator and features related to AMP caches.
+  * Facilitator: @Gregable
+

--- a/working-groups/README.md
+++ b/working-groups/README.md
@@ -1,7 +1,7 @@
 # Working Groups
 
 
-An AMP [Working Groups](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md#working-groups) is a segment of the community with knowledge/interest in specific area of AMP.  Working Groups are created by AMP’s [Technical Steering Committee](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md#technical-steering-committee-tsc). 
+An AMP [Working Group](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md#working-groups) is a segment of the community with knowledge/interest in specific area of AMP.  Working Groups are created by AMP’s [Technical Steering Committee](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md#technical-steering-committee-tsc). 
 
 AMP’s Working Groups are:
 

--- a/working-groups/README.md
+++ b/working-groups/README.md
@@ -17,6 +17,9 @@ AMP’s Working Groups are:
 * **Approvers.**
   * Responsible for approving changes that have a significant impact on AMP's behavior or significant new features as described in the feature and bug fix process.
   * Facilitator: @dvoytenko
+* **Code of Conduct.**
+  * Responsible for enforcing AMP's [Code of Conduct](https://github.com/ampproject/meta/blob/master/CODE_OF_CONDUCT.md).  (The Technical Steering Committee delegates its responsibility for enforcement of the Code of Conduct to this Working Group.)
+  * Facilitator: @nainar
 * **Infrastructure.**
   * Responsible for AMP's infrastructure, including building, testing and release.
   * Facilitator: @rsimha
@@ -38,4 +41,7 @@ AMP’s Working Groups are:
 * **Validation & caching.**
   * Responsible for AMP's validator and features related to AMP caches.
   * Facilitator: @Gregable
+* **Viewers.**
+  * Responsible for ensuring support for AMP viewers and for the [amp-viewer project](https://github.com/ampproject/amp-viewer).
+  * Facilitator: @ericfs
 

--- a/working-groups/README.md
+++ b/working-groups/README.md
@@ -5,6 +5,9 @@ An AMP [Working Groups](https://github.com/ampproject/meta/blob/master/GOVERNANC
 
 AMP’s Working Groups are:
 
+* **Access control and subscriptions.**
+  * Responsible for user specific controlled access to AMP content (amp-subscriptions, amp-access and related extensions)
+  * Facilitator: @jpettitt 
 * **Ads & analytics.**
   * Responsible for ads & analytics features and integrations in AMP.
   * Facilitator: @lannka

--- a/working-groups/README.md
+++ b/working-groups/README.md
@@ -33,11 +33,8 @@ AMP’s Working Groups are:
   * Responsible for implementing and improving AMP's story format (amp-story).
   * Facilitator: @newmuis
 * **UI.**
-  * Responsible for AMP's visual components & interactions.  The UI WG also has overall responsibility for ensuring AMP is accessible, though each WG is responsible for ensuring accessibility within their areas of responsibility. 
+  * Responsible for AMP's visual components & interactions and AMP's overall user experience (including published guidelines for AMP UX).  The UI WG also has overall responsibility for ensuring AMP is accessible, though each WG is responsible for ensuring accessibility within their areas of responsibility. 
   * Facilitator: @aghassemi
-* **UX.**
-  * Responsible for AMP’s user experience, including published guidelines for AMP UX.
-  * Facilitator: @spacedino
 * **Validation & caching.**
   * Responsible for AMP's validator and features related to AMP caches.
   * Facilitator: @Gregable


### PR DESCRIPTION
As described in AMP's new governance model (#1), the Technical Steering Committee (TSC) is responsible for creating Working Groups and describing each Working Group's mandate.

This PR proposes the initial set of Working Groups for the TSC to create.  The proposal is based on the informal groups that currently operate in the AMP open source project.

A facilitator is also proposed for each Working Group.  The person who currently has the most familiarity with each Working Group's area of responsibility is proposed as the facilitator for that Working Group.

The governance model indicates that the TSC also sets the initial membership of each Working Group.  For now this proposal only designates the facilitators.  The full initial membership of each Working Group will be specified separately.

/cc @cramforce @lannka @choumx @dvoytenko @rsimha @pbakaus @jridgewell @newmuis @aghassemi @spacedino @Gregable @cramforce 