### PR TITLE
Adding anchors to GOVERNANCE.md

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -4,23 +4,23 @@
 
 * **Advisory Committee (AC).**  A group of people with representation from a variety of AMP's constituencies including Users, End-users and Collaborators who provide advice to the Technical Steering Committee.
 
-* **Collaborators.**  People who have been granted write-access to ampproject repositories. Collaborators can merge pull requests when their code is reviewed and has **Owners** approval.
+* <strong id=collaborator>Collaborators.</strong>  People who have been granted write-access to ampproject repositories. Collaborators can merge pull requests when their code is reviewed and has **Owners** approval.
 
-* **Contributors**.  People who have opened a pull request or an issue, or commented on an issue. Contributors are granted certain permissions on the repositories to make it easier to participate--e.g. assigning issues, attaching labels to issues, etc.
+* <strong id=contributor>Contributors</strong>.  People who have opened a pull request or an issue, or commented on an issue. Contributors are granted certain permissions on the repositories to make it easier to participate--e.g. assigning issues, attaching labels to issues, etc.
 
-* **Facilitator.**  A member of a governance body who is responsible for facilitating the consensus-based decision making process and acting as a representative to other governance bodies.
+* <strong id=facilitator>Facilitator.</strong>  A member of a governance body who is responsible for facilitating the consensus-based decision making process and acting as a representative to other governance bodies.
 
-* **Governance body** Any of the Advisory Committee, Technical Steering Committee, and Workings Groups.
+* <strong id=governance-body>Governance body</strong> Any of the Advisory Committee, Technical Steering Committee, and Workings Groups.
 
-* **Users.** Developers who use AMP but haven’t contributed to it (yet).
+* <strong id=user>Users.</strong> Developers who use AMP but haven’t contributed to it (yet).
 
-* **End-users**. People who consume content distributed using the AMP format.
+* <strong id=end-user>End-users</strong>. People who consume content distributed using the AMP format.
 
-* **Owners**.  People who are most familiar with a particular set of code and who have been granted the power (by Owners at a higher level) for approving changes to that code.  AMP will use a system similar to [Chromium's OWNERS](https://chromium.googlesource.com/chromium/src/+/master/docs/code_reviews.md#OWNERS-files) system.  The AMP Project will follow Chromium's [expectation for owners](https://chromium.googlesource.com/chromium/src/+/master/docs/code_reviews.md#expectations-of-owners).
+* <strong id=owner>Owners</strong>.  People who are most familiar with a particular set of code and who have been granted the power (by Owners at a higher level) for approving changes to that code.  AMP will use a system similar to [Chromium's OWNERS](https://chromium.googlesource.com/chromium/src/+/master/docs/code_reviews.md#OWNERS-files) system.  The AMP Project will follow Chromium's [expectation for owners](https://chromium.googlesource.com/chromium/src/+/master/docs/code_reviews.md#expectations-of-owners).
 
 * **Technical Steering Committee (TSC).**  A group of people who set AMP's technical & product direction.
 
-* **Working Groups (WG)**.  A group of people who have a familiarity and interest in a given area; may be cross-cutting (e.g. "Documentation") or focused on a given area (e.g. "Ads & Analytics" or "Runtime").  These are formally recognized by the TSC, but may form informally.
+* <strong id=wg>Working Groups (WG)</strong>.  A group of people who have a familiarity and interest in a given area; may be cross-cutting (e.g. "Documentation") or focused on a given area (e.g. "Ads & Analytics" or "Runtime").  These are formally recognized by the TSC, but may form informally.
 
 ## Governance Structures
 


### PR DESCRIPTION
This is useful to be able to reference terms from other documents. (Note you'll have to prefix the identifier with `user-content-`.)