### PR TITLE
Link to the TSC/AC/WG on meta/README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -3,3 +3,8 @@
 This is the repository for information about the AMP Project.
 
 The main code for the AMP Project lives in the [amphtml repo](https://github.com/ampproject/amphtml).
+
+AMP's [governance model](GOVERNANCE.md) defines how decisions about AMP's product and technical direction and day-to-day work gets done.  The governance structures include:
+* the [Technical Steering Committee (TSC)](https://github.com/ampproject/meta-tsc)
+* the [Advisory Committee (AC)](https://github.com/ampproject/meta-ac)
+* [Working Groups](https://github.com/ampproject/meta/tree/master/working-groups)

--- a/README.md
+++ b/README.md
@@ -4,7 +4,7 @@ This is the repository for information about the AMP Project.
 
 The main code for the AMP Project lives in the [amphtml repo](https://github.com/ampproject/amphtml).
 
-AMP's [governance model](GOVERNANCE.md) defines how decisions about AMP's product and technical direction and day-to-day work gets done.  The governance structures include:
+AMP's [governance model](GOVERNANCE.md) defines how decisions about AMP's product and technical direction are made and how day-to-day work gets done.  The governance structures include:
 * the [Technical Steering Committee (TSC)](https://github.com/ampproject/meta-tsc)
 * the [Advisory Committee (AC)](https://github.com/ampproject/meta-ac)
 * [Working Groups](https://github.com/ampproject/meta/tree/master/working-groups)


### PR DESCRIPTION
This adds links on meta/README.md to the TSC & AC repos and the WG page.