### PR TITLE
Add Performance Working Group

### DIFF
--- a/working-groups/README.md
+++ b/working-groups/README.md
@@ -26,6 +26,9 @@ AMP’s Working Groups are:
 * **Outreach.**
   * Responsible for helping developers who use AMP remain productive and keeping the AMP community healthy.  This includes maintaining and enhancing AMP's developer-facing sites and documentation, maintaining communication channels, organizing community events, etc.
   * Facilitator: @pbakaus
+* **Performance.**
+  * Responsible for monitoring and improving AMP's load and runtime performance for compliant documents.
+  * Facilitator: @kristoferbaxter
 * **Runtime.**
   * Responsible for AMP's core runtime, such as layout/rendering and data binding.
   * Facilitator: @jridgewell


### PR DESCRIPTION
Adds a new Performance Working Group, whose mandate is to monitor and improve the load and runtime performance of AMP documents.

Two members are initially in the proposal, @kristoferbaxter (facilitator) and @prateekbh.

Skeleton for `@ampproject/wg-performance` has been created here (https://github.com/kristoferbaxter/wg-performance) and would be moved under the `@ampproject` repository namespace if the TSC agrees to the addition. 