### PR TITLE
Aligns GOVERNANCE.md with the OpenJS AMP Charter

### DIFF
--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -45,7 +45,8 @@ The Advisory Committee provides perspective and advice to the Technical Steering
 * Sets and maintains the project’s feature and bug fix process.
 * Enforces the Code of Conduct.
 * Approves changes to the AMP Charter in coordination with the OpenJS CPC as described in the [AMP Charter](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md).
-* The TSC may designate entities to perform legal, security and privacy reviews of AMP code/features. 
+* The TSC may designate entities to perform security and privacy reviews of AMP code/features.
+* The TSC may escalate legal questions to the Foundation. 
 * Decisions within the TSC follow the decision-making policy, and are facilitated by the Facilitator or their designate.
 
 #### Membership

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -36,6 +36,7 @@ The Advisory Committee provides perspective and advice to the Technical Steering
 
 #### Role
 
+* Technical leadership of the AMP project is delegated to the TSC by the OpenJS Cross Project Council (CPC) in accordance with the [AMP Charter](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md).
 * The TSC's primary role is setting AMP's technical & product direction based on the [project guidelines](https://www.ampproject.org/about/amp-design-principles/).
 * Creates a product roadmap in consultation with the Working Groups.
 * Creates Working Groups and sets the initial membership & initial Facilitator of the Working Groups.  The TSC may initiate the creation of Working Groups or a group of people with a common interest may request recognition as a Working Group.
@@ -43,7 +44,8 @@ The Advisory Committee provides perspective and advice to the Technical Steering
 * Sets and maintains the project guidelines.
 * Sets and maintains the project’s feature and bug fix process.
 * Enforces the Code of Conduct.
-* The TSC may designate entities to perform legal, security and privacy reviews of AMP code/features.
+* Approves changes to the AMP Charter in coordination with the OpenJS CPC as described in the [AMP Charter](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md).
+* The TSC may designate entities to perform legal, security and privacy reviews of AMP code/features. 
 * Decisions within the TSC follow the decision-making policy, and are facilitated by the Facilitator or their designate.
 
 #### Membership
@@ -54,7 +56,7 @@ The Advisory Committee provides perspective and advice to the Technical Steering
 * Once established the TSC sets its own membership through the consensus-based process.
 * The TSC shall have a goal of having no more than ⅓ of the TSC from one employer.  Given the requirement that membership in the TSC requires recognized technical and/or product experience with AMP this may not be feasible at the time the TSC is formed, but the TSC should actively work towards this goal.
 * Entities (such as a company) may be granted seats on the TSC.  In these cases certain conditions may be placed on the seat (such as maintaining committed resources to the project). The entity may designate the individual representing the entity at the TSC and may change this individual at their discretion.
-* The TSC will designate a Facilitator from among its members for the purposes of facilitating the consensus-based decision-making process.
+* The TSC will designate a Facilitator from among its members for the purposes of facilitating the consensus-based decision-making process and for representing the TSC to the OpenJS CPC.
 
 ### Working Groups
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -44,7 +44,7 @@ The Advisory Committee provides perspective and advice to the Technical Steering
 * Sets and maintains the project guidelines.
 * Sets and maintains the project’s feature and bug fix process.
 * Enforces the Code of Conduct.
-* Approves changes to the AMP Charter in coordination with the OpenJS CPC as described in the [AMP Charter](https://github.com/ampproject/meta/blob/master/CHARTER.md).
+* Approves changes to the AMP Charter and this document in coordination with the OpenJS CPC as described in the [AMP Charter](https://github.com/ampproject/meta/blob/master/CHARTER.md).
 * The TSC may designate entities to perform security and privacy reviews of AMP code/features.
 * The TSC may escalate legal questions to the Foundation. 
 * Decisions within the TSC follow the decision-making policy, and are facilitated by the Facilitator or their designate.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -36,7 +36,7 @@ The Advisory Committee provides perspective and advice to the Technical Steering
 
 #### Role
 
-* Technical leadership of the AMP project is delegated to the TSC by the OpenJS Cross Project Council (CPC) in accordance with the [AMP Charter](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md).
+* Technical leadership of the AMP project is delegated to the TSC by the OpenJS Cross Project Council (CPC) in accordance with the [AMP Charter](https://github.com/ampproject/meta/blob/master/CHARTER.md).
 * The TSC's primary role is setting AMP's technical & product direction based on the [project guidelines](https://www.ampproject.org/about/amp-design-principles/).
 * Creates a product roadmap in consultation with the Working Groups.
 * Creates Working Groups and sets the initial membership & initial Facilitator of the Working Groups.  The TSC may initiate the creation of Working Groups or a group of people with a common interest may request recognition as a Working Group.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -97,7 +97,7 @@ The Advisory Committee provides perspective and advice to the Technical Steering
 
 ## Contributor License Agreement
 
-* The AMP Project requires all Owners, Collaborators, and Contributors who open a pull request to either sign an individual Contributor License Agreement (CLA) or be covered by a corporate CLA in order to protect contributors and users in issues of intellectual property.
+* The AMP Project requires all Owners, Collaborators, and Contributors who open a pull request to either accept the terms of an individual Contributor License Agreement (CLA) or be covered by a corporate CLA in order to protect contributors and users in issues of intellectual property.
 
 * TSC members which aren't already covered by an individual or corporate CLA are required to be covered upon joining the TSC.
 

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -44,7 +44,7 @@ The Advisory Committee provides perspective and advice to the Technical Steering
 * Sets and maintains the project guidelines.
 * Sets and maintains the project’s feature and bug fix process.
 * Enforces the Code of Conduct.
-* Approves changes to the AMP Charter in coordination with the OpenJS CPC as described in the [AMP Charter](https://github.com/ampproject/meta/blob/master/GOVERNANCE.md).
+* Approves changes to the AMP Charter in coordination with the OpenJS CPC as described in the [AMP Charter](https://github.com/ampproject/meta/blob/master/CHARTER.md).
 * The TSC may designate entities to perform security and privacy reviews of AMP code/features.
 * The TSC may escalate legal questions to the Foundation. 
 * Decisions within the TSC follow the decision-making policy, and are facilitated by the Facilitator or their designate.

--- a/GOVERNANCE.md
+++ b/GOVERNANCE.md
@@ -57,7 +57,7 @@ The Advisory Committee provides perspective and advice to the Technical Steering
 * Once established the TSC sets its own membership through the consensus-based process.
 * The TSC shall have a goal of having no more than ⅓ of the TSC from one employer.  Given the requirement that membership in the TSC requires recognized technical and/or product experience with AMP this may not be feasible at the time the TSC is formed, but the TSC should actively work towards this goal.
 * Entities (such as a company) may be granted seats on the TSC.  In these cases certain conditions may be placed on the seat (such as maintaining committed resources to the project). The entity may designate the individual representing the entity at the TSC and may change this individual at their discretion.
-* The TSC will designate a Facilitator from among its members for the purposes of facilitating the consensus-based decision-making process and for representing the TSC to the OpenJS CPC.
+* The TSC will designate a Facilitator from among its members for the purposes of facilitating the consensus-based decision-making process.
 
 ### Working Groups
 


### PR DESCRIPTION
This is a draft pull request with a few changes that will be needed as part of AMP moving to the OpenJS Foundation.

The AMP charter is still in draft form, based on the [charter template](https://github.com/openjs-foundation/cross-project-council/blob/master/PROJECT_CHARTER_TEMPLATE.md).  After the CPC approves the charter, we will be able to merge in the charter and these modifications.

Changes in this PR include:

- Indicating that the TSC's role is delegated from the OpenJSF CPC
- Referencing the new role the TSC has in updating the AMP charter (with the exact details of what that role is left to the charter, to avoid having the same mechanic duplicated in two different documents).
- Indicating that the Facilitator represents the TSC to the OpenJSF CPC.
- Indicating that legal issues may be delegated to OpenJSF.

Resolves #46  
Blocks on ampproject/meta-tsc#25

/cc @tobie, @brianwarner 